### PR TITLE
Remove dependency on spotless + fix logging deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'java'
-    id "com.diffplug.spotless" version "5.2.0"
 }
 
 repositories {
@@ -11,7 +10,7 @@ repositories {
     mavenCentral()
 }
 
-def runeLiteVersion = '1.6.25'
+def runeLiteVersion = '1.7.7'
 
 dependencies {
     compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion
@@ -20,20 +19,12 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.4'
 
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.slf4j:slf4j-simple:1.7.12'
-    testImplementation group: 'net.runelite', name: 'client', version: runeLiteVersion, {
-        exclude group: 'ch.qos.logback', module: 'logback-classic'
-    }
-}
-
-spotless {
-    java {
-        googleJavaFormat('1.7')
-    }
+    testImplementation group: 'net.runelite', name: 'client', version: runeLiteVersion
+    testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
 group = 'com.recoilplugin'
-version = '1.0-SNAPSHOT'
+version = '1.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
This plugin is failing to build on the plugin hub:
[261c8a3dc58e6381194406d8ce9ebfbf399cb0e0.log](https://github.com/delps1001/recoil-plugin/files/6489753/261c8a3dc58e6381194406d8ce9ebfbf399cb0e0.log)

It's failing because the `spotless` plugin isn't verified against supplychain attacks, and because the template logging dependencies in `build.gradle` have changed. More info here on pinning: https://github.com/runelite/plugin-hub#third-party-dependencies

### Spotless
With the new dependency declaration format that the plugin hub uses, it might just be easier to remove the dependency on `spotless` altogether and move to an IDE-based formatter like CheckStyle. If you keep it in, you'll need a dependency declaration block and if you remove it you won't need anything, since you don't depend on any other third party deps.

### Logging
The explicit dependency on `slf4j-simple` is no longer standard, since the plugin template now uses the `runelite-client` logger. These dependencies were also not pinned, so were included in causing the build to fail.